### PR TITLE
Switch the unbounded dropwizard metrics queues to bounded queues

### DIFF
--- a/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
+++ b/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
@@ -227,7 +227,9 @@ public class HadoopMetrics2Reporter extends ScheduledReporter implements Metrics
       builder.setContext(context);
     }
 
-    snapshotAllMetrics(builder);
+    synchronized (this) {
+      snapshotAllMetrics(builder);
+    }
 
     metrics2Registry.snapshot(builder, all);
   }
@@ -411,7 +413,7 @@ public class HadoopMetrics2Reporter extends ScheduledReporter implements Metrics
    * @param queue The queue to add elements to
    * @param metrics The metrics elements to add to the queue
    */
-  protected <T> void addEntriesToQueue(ArrayBlockingQueue<Entry<String,T>> queue, SortedMap<String, T> metrics) {
+  protected <T> void addEntriesToQueue(ArrayBlockingQueue<Entry<String,T>> queue, SortedMap<String,T> metrics) {
     final Set<Entry<String,T>> metricsToAdd = metrics.entrySet();
     int entriesLeftToAdd = metricsToAdd.size();
 

--- a/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
+++ b/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
@@ -192,6 +192,8 @@ public class HadoopMetrics2Reporter extends ScheduledReporter implements Metrics
   private final String context;
   private final int maxMetricsPerType;
 
+  // TODO Adding to the queues and removing from them are now guarded by explicit synchronization
+  // so these don't need to be safe for concurrency anymore.
   @SuppressWarnings("rawtypes")
   private final ArrayBlockingQueue<Entry<String, Gauge>> dropwizardGauges;
   private final ArrayBlockingQueue<Entry<String, Counter>> dropwizardCounters;
@@ -227,6 +229,8 @@ public class HadoopMetrics2Reporter extends ScheduledReporter implements Metrics
       builder.setContext(context);
     }
 
+    // Synchronizing here ensures that the dropwizard metrics collection side is excluded from executing
+    // at the same time we are pulling elements from the queues.
     synchronized (this) {
       snapshotAllMetrics(builder);
     }

--- a/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
+++ b/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
@@ -425,6 +425,7 @@ public class HadoopMetrics2Reporter extends ScheduledReporter implements Metrics
     for (Entry<String,T> entry : metricsToAdd) {
       // Assume that we have space (normal condition)
       if (!queue.offer(entry)) {
+        LOG.debug("Failed to add metrics element. Removing {} elements from queue", entriesLeftToAdd);
         // If we fail to add the entry to the tail of the queue, try to free up enough space
         // for all remaining entries
         for (int i = 0; i < entriesLeftToAdd; i++) {

--- a/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
+++ b/src/main/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2Reporter.java
@@ -145,20 +145,18 @@ public class HadoopMetrics2Reporter extends ScheduledReporter implements Metrics
     /**
      * Overrides the default maximum number of Dropwizard {@link Metric} instances which are cached
      * to be passed to the Hadoop Metrics2 {@link MetricsCollector}. Default is {@link #DEFAULT_MAXIMUM_METRICS_PER_TYPE}.
-     * Negative values are interpreted as {@link Integer#MAX_VALUE} and a value of zero is disallowed. 
+     * Only positive values are allowed, negative numbers and zero are disallowed. 
      *
      * @param maxMetricsPerType The number of metric instances which are allowed by type.
      * @return {@code this}
+     * @throws IllegalArgumentException if {@code maxMetricsPerType} is non-positive.
      */
     public Builder maximumCachedMetricsPerType(int maxMetricsPerType) {
       if (0 < maxMetricsPerType) {
         this.maxMetricsPerType = maxMetricsPerType;
-      } else if (0 > maxMetricsPerType) {
-        this.maxMetricsPerType = Integer.MAX_VALUE;
-      } else {
-        throw new IllegalArgumentException("Maximum number of cached metrics of zero (0) is disallowed");
+        return this;
       }
-      return this;
+      throw new IllegalArgumentException("The maximum number of cached metrics must be positive");
     }
 
     /**

--- a/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/BoundedQueueMaintenanceTest.java
+++ b/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/BoundedQueueMaintenanceTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.joshelser.dropwizard.metrics.hadoop;
+
+import static org.junit.Assert.*;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doCallRealMethod;
+
+import java.util.Map.Entry;
+import java.util.Iterator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for the maintaining of the bounded queues of dropwizard metrics.
+ */
+public class BoundedQueueMaintenanceTest {
+
+  private HadoopMetrics2Reporter reporter;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setup() {
+    this.reporter = mock(HadoopMetrics2Reporter.class);
+
+    // Call the real addEntriesToQueue method
+    doCallRealMethod().when(reporter).addEntriesToQueue(any(ArrayBlockingQueue.class), any(SortedMap.class));
+  }
+
+  private void loadMap(TreeMap<String,Object> map, int numElementsToLoad) {
+    final Object o = new Object();
+    for (int i = 0; i < numElementsToLoad; i++) {
+      map.put("metric" + i, o);
+    }
+  }
+  
+  @Test
+  public void metricsInExcessOfLimitClearQueue() {
+    @SuppressWarnings("unchecked")
+    ArrayBlockingQueue<Entry<String,Object>> queue = mock(ArrayBlockingQueue.class);
+    TreeMap<String,Object> metrics = new TreeMap<>();
+    loadMap(metrics, 2);
+
+    // Super small limit on the number of metrics we will aggregate
+    when(reporter.getMaxMetricsPerType()).thenReturn(1);
+
+    reporter.addEntriesToQueue(queue, metrics);
+
+    verify(queue).clear();
+  }
+
+  @Test
+  public void queuesAreBounded() {
+    int limit = 5;
+    when(reporter.getMaxMetricsPerType()).thenReturn(limit);
+
+    ArrayBlockingQueue<Entry<String,Object>> queue = new ArrayBlockingQueue<>(limit);
+    TreeMap<String,Object> metrics = new TreeMap<>();
+    // [metric0, metric1, metric2]
+    loadMap(metrics, 3);
+
+    // Add three elements
+    reporter.addEntriesToQueue(queue, metrics);
+
+    // All three elements are added
+    assertEquals(3, queue.size());
+
+    // Add three elements again
+    reporter.addEntriesToQueue(queue, metrics);
+
+    // We filled up the queue
+    assertEquals(limit, queue.size());
+
+    // [0,] 1, 2, 0, 1 ,2
+    assertEquals("metric1", queue.peek().getKey());
+
+    reporter.addEntriesToQueue(queue, metrics);
+
+    // Queue is still full
+    assertEquals(5, queue.size());
+
+    // [0, 1, 2, 0,] 1, 2, 0, 1, 2
+    assertEquals("metric1", queue.peek().getKey());
+  }
+
+  @Test
+  public void queuesConsumed() {
+    int limit = 10;
+    when(reporter.getMaxMetricsPerType()).thenReturn(limit);
+
+    ArrayBlockingQueue<Entry<String,Object>> queue = new ArrayBlockingQueue<>(limit);
+    TreeMap<String,Object> metrics = new TreeMap<>();
+    loadMap(metrics, 6);
+
+    reporter.addEntriesToQueue(queue, metrics);
+
+    assertEquals(metrics.size(), queue.size());
+
+    // Fake out `getMetrics()`
+    // TODO refactor the reporter so that we can call the actual implementation
+    Iterator<Entry<String,Object>> iter = queue.iterator();
+    while (iter.hasNext()) {
+      iter.next();
+      // snapshot the dropwizard metric into the metrics2 metric
+      iter.remove();
+    }
+
+    assertEquals(0, queue.size());
+
+    // Add 6 entries
+    reporter.addEntriesToQueue(queue, metrics);
+
+    // Verify 6 entries
+    assertEquals(metrics.size(), queue.size());
+
+    // Add another 6 entries
+    reporter.addEntriesToQueue(queue, metrics);
+
+    // We should have hit the limit
+    assertEquals(limit, queue.size());
+
+    // Consume 8 records
+    iter = queue.iterator();
+    for (int i = 0; i < 8; i++) {
+      assertTrue(iter.hasNext());
+      iter.next();
+      // snapshot the dropwizard metric into the metrics2 metric
+      iter.remove();
+    }
+
+    assertEquals(2, queue.size());
+
+    // Add six more one final time
+    reporter.addEntriesToQueue(queue, metrics);
+
+    assertEquals(8, queue.size());
+  }
+}

--- a/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2ReporterTest.java
+++ b/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/HadoopMetrics2ReporterTest.java
@@ -326,4 +326,28 @@ public class HadoopMetrics2ReporterTest {
     // Verify the units
     verifyRecordBuilderUnits(recordBuilder);
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void builderNegativeMaxCachedSize() {
+    Builder builder = HadoopMetrics2Reporter.forRegistry(mockRegistry)
+        .maximumCachedMetricsPerType(-1);
+
+    final String jmxContext = "MyJmxContext;sub=Foo";
+    final String desc = "Description";
+    final String recordName = "Metrics";
+
+    builder.build(mockMetricsSystem, jmxContext, desc, recordName);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void builderZeroMaxCachedSize() {
+    Builder builder = HadoopMetrics2Reporter.forRegistry(mockRegistry)
+        .maximumCachedMetricsPerType(0);
+
+    final String jmxContext = "MyJmxContext;sub=Foo";
+    final String desc = "Description";
+    final String recordName = "Metrics";
+
+    builder.build(mockMetricsSystem, jmxContext, desc, recordName);
+  }
 }

--- a/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/StandaloneExample.java
+++ b/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/StandaloneExample.java
@@ -39,7 +39,7 @@ public class StandaloneExample {
     final MetricRegistry metrics = new MetricRegistry();
 
     final HadoopMetrics2Reporter metrics2Reporter = HadoopMetrics2Reporter.forRegistry(metrics)
-        .maximumCachedMetricsPerType(10)
+        .maximumCachedMetricsPerType(100)
         .build(DefaultMetricsSystem.initialize("StandaloneTest"), // The application-level name
                "Test", // Component name
                "Test", // Component description
@@ -65,7 +65,7 @@ public class StandaloneExample {
     // How often will the dropwziard metrics be logged to the console
     consoleReporter.start(2, TimeUnit.SECONDS);
 
-    generateMetrics(metrics, 5000, 50, TimeUnit.MILLISECONDS, metrics2Reporter, 5);
+    generateMetrics(metrics, 5000, 25, TimeUnit.MILLISECONDS, metrics2Reporter, 10);
   }
 
   /**

--- a/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/StandaloneExample.java
+++ b/src/test/java/com/github/joshelser/dropwizard/metrics/hadoop/StandaloneExample.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 Josh Elser
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.joshelser.dropwizard.metrics.hadoop;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.configuration.SubsetConfiguration;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.sink.FileSink;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * A little utility to try to simulate "real-life" scenarios. Doesn't actually assert anything yet
+ * so it requires human interaction.
+ */
+public class StandaloneExample {
+
+  public static void main(String[] args) throws Exception {
+    final MetricRegistry metrics = new MetricRegistry();
+
+    final HadoopMetrics2Reporter metrics2Reporter = HadoopMetrics2Reporter.forRegistry(metrics)
+        .maximumCachedMetricsPerType(10)
+        .build(DefaultMetricsSystem.initialize("StandaloneTest"), // The application-level name
+               "Test", // Component name
+               "Test", // Component description
+               "Test"); // Name for each metric record
+    final ConsoleReporter consoleReporter = ConsoleReporter.forRegistry(metrics).build();
+
+    MetricsSystem metrics2 = DefaultMetricsSystem.instance();
+    // Writes to stdout without a filename configuration
+    // Will be invoked every 10seconds by default
+    FileSink sink = new FileSink();
+    metrics2.register("filesink", "filesink", sink);
+    sink.init(new SubsetConfiguration(null, null) {
+      public String getString(String key) {
+        if (key.equals("filename")) {
+          return null;
+        }
+        return super.getString(key);
+      }
+    });
+
+    // How often should the dropwizard reporter be invoked
+    metrics2Reporter.start(500, TimeUnit.MILLISECONDS);
+    // How often will the dropwziard metrics be logged to the console
+    consoleReporter.start(2, TimeUnit.SECONDS);
+
+    generateMetrics(metrics, 5000, 50, TimeUnit.MILLISECONDS, metrics2Reporter, 5);
+  }
+
+  /**
+   * Runs a number of threads which generate metrics.
+   */
+  public static void generateMetrics(final MetricRegistry metrics, final long metricsToGenerate, final int period,
+      final TimeUnit periodTimeUnit, HadoopMetrics2Reporter metrics2Reporter, int numThreads) throws Exception {
+    final ScheduledExecutorService pool = Executors.newScheduledThreadPool(numThreads);
+    final CountDownLatch latch = new CountDownLatch(numThreads);
+
+    for (int i = 0; i < numThreads; i++) {
+      final int id = i;
+      final int halfPeriod = (period / 2);
+      Runnable task = new Runnable() {
+        private long executions = 0;
+        final Random r = new Random();
+
+        @Override
+        public void run() {
+          if (executions >= metricsToGenerate) {
+            return;
+          }
+          metrics.counter("foo counter thread" + id).inc();
+          executions++;
+          if (executions < metricsToGenerate) {
+            pool.schedule(this, period + r.nextInt(halfPeriod), periodTimeUnit);
+          } else {
+            latch.countDown();
+          }
+        }
+      };
+      pool.schedule(task, period, periodTimeUnit);
+    }
+
+    while (!latch.await(2, TimeUnit.SECONDS)) {
+      metrics2Reporter.printQueueDebugMessage();
+    }
+
+    pool.shutdown();
+    pool.awaitTermination(5000, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -20,4 +20,4 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 
 # Set the pattern for each log message
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %C - %m%n

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -21,3 +21,5 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 # Set the pattern for each log message
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %C - %m%n
+
+#log4j.logger.com.github.joshelser.dropwizard.metrics.hadoop=TRACE


### PR DESCRIPTION
If the metrics2 subsystem isn't up, we want to make sure we don't
hold an excessive number of metrics in memory.
